### PR TITLE
Feat/upgrade birt packages to v4.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The ZIP file will be produced by executing the task `buildBirtOsgi`.
 ## Creating the BIRT Report Framework
 
 The gradle build file in 'birt-report-framework' includes two tasks which will create a ZIP file as the OSGI Report Framework.
-* Download version 4.6.0 of the BIRT Report Framework original ZIP file from the official download page.
+* Download version 4.16.0 of the BIRT Report Framework original ZIP file from the official download page.
 * Unzip the archive file to folder `/framework`.
 * Copy Jars listed below from the BIRT OSGI sub-project to `/framework`.
   * 'org.apache.batik.i18n_1.14.0.v20210324-0332.jar'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ from the [Eclipse BIRT download page](https://download.eclipse.org/birt/download
 solved by downloading the full packages, adding a variety of tweaks to make the packages work with oEQ, and publishing
 to remote repository. Unfortunately, the knowledge of what tweaks were needed and how to add them was lost. 
 
-As a result, above manual work has been done again with version 4.9.0 of the two libraries. And all the steps required to
+As a result, above manual work has been done again with version 4.16.0 of the two libraries. And all the steps required to
 make the libraries work with oEQ are captured in this project, which uses two sub-projects to build the BIRT OSGI runtime 
 library and the BIRT Report Framework respectively. However, there is no guarantee that the steps described below will work
 perfectly with any future version of the BIRT OSGI runtime library and BIRT Report Framework.
@@ -33,12 +33,8 @@ start with.
 ## Creating the BIRT OSGI runtime library
 
 The gradle build file in 'birt-osgi' includes two tasks which will create a ZIP file for the OSGI runtime library.
-* Download version 4.9.0 of the BIRT OSGI original ZIP file from the official download page.
+* Download version 4.16.0 of the BIRT OSGI original ZIP file from the official download page.
 * Unzip the archive file to folder `/osgi`.
-* Download the BIRT compatibility Jar from Maven central to `/osgi/ReportEngine/platform/plugins`. The version is pinned to 1.2.500.
-* Update file 'bundles.info' in `osgi/ReportEngine/platform/configuration/org.eclipse.equinox.simpleconfigurator`
-by appending below line to include the info of the compatibility Jar.
-  * org.eclipse.osgi.compatibility.state,1.2.500.v20210730-0750,plugins/org.eclipse.osgi.compatibility.state-1.2.500.jar,4,false
 * Compress `/osgi` to a ZIP file named `birt-osgi-${project.version}`.
 
 The ZIP file will be produced by executing the task `buildBirtOsgi`.
@@ -50,20 +46,26 @@ The ZIP file will be produced by executing the task `buildBirtOsgi`.
 ## Creating the BIRT Report Framework
 
 The gradle build file in 'birt-report-framework' includes two tasks which will create a ZIP file as the OSGI Report Framework.
-* Download version 4.9.0 of the BIRT Report Framework original ZIP file from the official download page.
+* Download version 4.6.0 of the BIRT Report Framework original ZIP file from the official download page.
 * Unzip the archive file to folder `/framework`.
 * Copy Jars listed below from the BIRT OSGI sub-project to `/framework`.
-  * 'org.eclipse.datatools.connectivity_1.14.102.201911250848.jar'
-  * 'org.eclipse.datatools.connectivity.oda_3.6.101.201811012051.jar'
-  * 'org.eclipse.datatools.connectivity.oda.consumer_3.4.101.201811012051.jar'
-  * 'org.eclipse.equinox.common_3.16.0.v20220211-2322.jar'
-  * 'org.eclipse.equinox.preferences_3.9.100.v20211021-1418.jar'
-  * 'org.eclipse.equinox.registry_3.11.100.v20211021-1418.jar'
-  * 'org.eclipse.core.runtime_3.24.100.v20220211-2001.jar'
   * 'org.apache.batik.i18n_1.14.0.v20210324-0332.jar'
-  * 'org.eclipse.osgi_3.17.200.v20220215-2237.jar'
-  * 'org.eclipse.birt.report.data.oda.jdbc_4.9.0.v202203150031/oda-jdbc.jar'
-* Extract `Tidy.jar` from `org.eclipse.birt.report.engine_4.9.0.v202203150031.jar` which is in the BIRT OSGI sub-project, and copy to `/framework`.
+  * 'org.eclipse.birt.report.engine.emitter.config.excel_4.16.0.v202406141054.jar'
+  * 'org.eclipse.birt.report.engine.emitter.prototype.excel_4.16.0.v202406141054.jar'
+  * 'org.eclipse.core.runtime_3.31.100.v20240524-2010.jar'
+  * 'org.eclipse.datatools.connectivity_1.15.0.202311071249.jar'
+  * 'org.eclipse.datatools.connectivity.oda_3.7.0.202311071249.jar'
+  * 'org.eclipse.datatools.connectivity.oda.consumer_3.5.0.202311071249.jar'
+  * 'org.eclipse.emf.common_2.30.0.v20240314-0928.jar'
+  * 'org.eclipse.emf.ecore_2.36.0.v20240203-0859.jar'
+  * 'org.eclipse.emf.ecore.xmi_2.37.0.v20231208-1346.jar'
+  * 'org.eclipse.emf.ecore.change_2.16.0.v20231208-1346.jar'
+  * 'org.eclipse.equinox.common_3.19.100.v20240524-2011.jar'
+  * 'org.eclipse.equinox.preferences_3.11.100.v20240327-0645.jar'
+  * 'org.eclipse.equinox.registry_3.12.100.v20240524-2011.jar'
+  * 'org.eclipse.osgi_3.20.0.v20240509-1421.jar'
+  * 'org.eclipse.birt.report.data.oda.jdbc_4.16.0.v202406141054/oda-jdbc.jar'
+* Extract `Tidy.jar` from `org.eclipse.birt.report.engine_4.16.0.v202406141054.jar` which is in the BIRT OSGI sub-project, and copy to `/framework`.
 * Compress `/framework` to a ZIP file named `birt-report-framework-${project.version}`.
 
 The ZIP file will be produced by executing the task `buildBirtReportFramework`.

--- a/birt-osgi/build.gradle
+++ b/birt-osgi/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.openequella'
-version '4.9.3'
+version '4.16.0'
 
 final osgiFolder = file("./osgi")
 final reportEngineFolder = file("${osgiFolder}/ReportEngine")
@@ -19,7 +19,7 @@ final artifactName = "${project.name}-${project.version}.zip"
 task prepareBirtOsgi(description: 'Prepare BIRT OSGI') {
   doFirst {
     println("Download the original BIRT OSGI package")
-    new URL("https://download.eclipse.org/birt/downloads/drops/R-R1-4.9.0-202203161719/birt-runtime-osgi-4.9.0-20220315.zip").withInputStream {
+    new URI("https://www.eclipse.org/downloads/download.php?file=/birt/updates/release/4.16.0/downloads/birt-runtime-osgi-4.16.0-202406141054.zip&r=1").toURL().withInputStream {
       originalFile << it
     }
 
@@ -28,24 +28,15 @@ task prepareBirtOsgi(description: 'Prepare BIRT OSGI') {
       from zipTree(originalFile)
       into osgiFolder
     }
-
-    println("Download the OSGI compatibility Jar")
-    new URL("https://repo1.maven.org/maven2/org/eclipse/platform/org.eclipse.osgi.compatibility.state/1.2.500/org.eclipse.osgi.compatibility.state-1.2.500.jar").withInputStream {
-      compatibilityJar << it
-    }
-
-    println("Update file 'bundles.info'")
-    file("${platformFolder}/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info")
-      .append("org.eclipse.osgi.compatibility.state,1.2.500.v20210730-0750,plugins/org.eclipse.osgi.compatibility.state-1.2.500.jar,4,false")
   }
 }
 
 task buildBirtOsgi(description: 'Create the openEquella specific BIRT OSGI library', type: Zip) {
-  archiveName artifactName
+  archiveFileName = artifactName
   from fileTree(reportEngineFolder)
   exclude '/samples'
   exclude '/genReport.*'
-  destinationDir file("./")
+  destinationDirectory = file("./")
 
   doLast {
     println("BIRT OSGI library has been successfully created.")

--- a/birt-report-framework/build.gradle
+++ b/birt-report-framework/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'com.github.openequella'
-version '4.9.3'
+version '4.16.0'
 
 final frameworkFolder = file("./framework")
 final osgiJarFolder = file("../birt-osgi/osgi/ReportEngine/platform/plugins")
@@ -27,8 +27,7 @@ class OSGIJar {
 task prepareBirtReportFramework(description: 'Prepare BIRT Report Framework') {
   doFirst {
     println("Download the original BIRT Report Framework package")
-    new URL("https://download.eclipse.org/birt/downloads/drops/R-R1-4.9.0-202203161719/birt-report-framework-4.9.0-20220315.zip").withInputStream {
-      originalFile << it
+    new URI("https://www.eclipse.org/downloads/download.php?file=/birt/updates/release/4.16.0/downloads/birt-report-framework-sdk-4.16.0-202406141054.zip&r=1").toURL().withInputStream {      originalFile << it
     }
 
     println("Unzip the BIRT Report Framework package")
@@ -45,25 +44,25 @@ task prepareBirtReportFramework(description: 'Prepare BIRT Report Framework') {
 
     println("Copy required Jars from the BIRT OSGI package")
     final jars = [
-      'org.apache.batik.i18n_1.14.0.v20210324-0332.jar',
-      'org.eclipse.birt.report.engine.emitter.config.excel_4.9.0.v202203150031.jar',
-      'org.eclipse.birt.report.engine.emitter.prototype.excel_4.9.0.v202203150031.jar',
-      'org.eclipse.core.runtime_3.24.100.v20220211-2001.jar',
-      'org.eclipse.datatools.connectivity_1.14.102.201911250848.jar',
-      'org.eclipse.datatools.connectivity.oda_3.6.101.201811012051.jar',
-      'org.eclipse.datatools.connectivity.oda.consumer_3.4.101.201811012051.jar',
-      'org.eclipse.emf.common_2.24.0.v20220123-0838.jar',
-      'org.eclipse.emf.ecore_2.26.0.v20220123-0838.jar',
-      'org.eclipse.emf.ecore.xmi_2.16.0.v20190528-0725.jar',
-      'org.eclipse.emf.ecore.change_2.14.0.v20190528-0725.jar',
-      'org.eclipse.equinox.common_3.16.0.v20220211-2322.jar',
-      'org.eclipse.equinox.preferences_3.9.100.v20211021-1418.jar',
-      'org.eclipse.equinox.registry_3.11.100.v20211021-1418.jar',
-      'org.eclipse.osgi_3.17.200.v20220215-2237.jar',
+      'org.apache.batik.i18n_1.17.0.v20231215-1130.jar',
+      'org.eclipse.birt.report.engine.emitter.config.excel_4.16.0.v202406141054.jar',
+      'org.eclipse.birt.report.engine.emitter.prototype.excel_4.16.0.v202406141054.jar',
+      'org.eclipse.core.runtime_3.31.100.v20240524-2010.jar',
+      'org.eclipse.datatools.connectivity_1.15.0.202311071249.jar',
+      'org.eclipse.datatools.connectivity.oda_3.7.0.202311071249.jar',
+      'org.eclipse.datatools.connectivity.oda.consumer_3.5.0.202311071249.jar',
+      'org.eclipse.emf.common_2.30.0.v20240314-0928.jar',
+      'org.eclipse.emf.ecore_2.36.0.v20240203-0859.jar',
+      'org.eclipse.emf.ecore.xmi_2.37.0.v20231208-1346.jar',
+      'org.eclipse.emf.ecore.change_2.16.0.v20231208-1346.jar',
+      'org.eclipse.equinox.common_3.19.100.v20240524-2011.jar',
+      'org.eclipse.equinox.preferences_3.11.100.v20240327-0645.jar',
+      'org.eclipse.equinox.registry_3.12.100.v20240524-2011.jar',
+      'org.eclipse.osgi_3.20.0.v20240509-1421.jar',
     ].collect { name -> new OSGIJar(osgiJarFolder, name) }
 
     final nestedJars = [
-      new OSGIJar(file("${osgiJarFolder.absolutePath}/org.eclipse.birt.report.data.oda.jdbc_4.9.0.v202203150031"), 'oda-jdbc.jar')
+      new OSGIJar(file("${osgiJarFolder.absolutePath}/org.eclipse.birt.report.data.oda.jdbc_4.16.0.v202406141054"), 'oda-jdbc.jar')
     ]
 
     (jars + nestedJars)
@@ -78,7 +77,7 @@ task prepareBirtReportFramework(description: 'Prepare BIRT Report Framework') {
 
     println("Extract Tidy.jar from one of the Report Engine Jars and copy to here")
     copy {
-      from zipTree(file("${osgiJarFolder}/org.eclipse.birt.report.engine_4.9.0.v202203150031.jar")).matching {
+      from zipTree(file("${osgiJarFolder}/org.eclipse.birt.report.engine_4.16.0.v202406141054.jar")).matching {
         include 'lib/Tidy.jar'
         eachFile { f ->
           f.path = f.path.replaceFirst("lib", '') // Only copy the Jar, not the folder.
@@ -94,9 +93,9 @@ task prepareBirtReportFramework(description: 'Prepare BIRT Report Framework') {
 }
 
 task buildBirtReportFramework(description: 'Create the openEquella specific BIRT Report Framework', type: Zip) {
-  archiveName artifactName
+  archiveFileName = artifactName
   from fileTree(frameworkFolder)
-  destinationDir file("./")
+  destinationDirectory = file("./")
 
   doLast {
     println("BIRT Report Framework has been successfully created.")

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,6 @@ plugins {
 }
 
 group 'com.github.openequella'
-version '4.9.3'
+version '4.16.0'
 
 build.dependsOn("birt-osgi:buildBirtOsgi", "birt-report-framework:buildBirtReportFramework")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade BIRT packages to the v4.16.0 which is the latest version by 29/07/2024.

By doing this upgrade, I was hoping to
* Reduce the number of security vulnerabilities 
* Fix a DOC format issue

Unfortunately, none of above is nicely addressed by the upgrade. Please check [this ticket](https://edalex.atlassian.net/browse/OEQ-2108) for the details of security vulnerabilities. 

For the format issue, I have raised a [discussion](https://github.com/eclipse-birt/birt/discussions/1818) in BIRT Github community. 

Although the upgrade does not achieve the two goals, we should still get it completed. At least, lots of dependencies have been upgraded in this version.

Lastly, I also upgrade Gradle to v8.7 which works fine with Java 21.